### PR TITLE
Refactor interface of custom groups creation

### DIFF
--- a/test.py
+++ b/test.py
@@ -66,9 +66,9 @@ def test_user_becomes_present(edap):
 
 
 def test_divisions_becomes_present(edap):
-    assert not edap.subobject_exists_at("ou=divisions", "organizationalUnit")
+    assert not edap.org_unit_exists("divisions")
     edap.create_org_unit("ou=divisions", edap.DIVISIONS_GROUP)
-    assert edap.subobject_exists_at("ou=divisions", "organizationalUnit")
+    assert edap.org_unit_exists("divisions")
 
 
 def test_it_division_becomes_present(edap):


### PR DESCRIPTION
Moved whole group creation functionality to `LdapGroupMixin`, with main `create_group` method, which takes group name, organizational unit, description (optionally)
Also left mixins for Division, Service, Franchise as frequently used ones, but refactored them to use interface of `LdapGroupMixin` group creation